### PR TITLE
remove account number field for keysign login

### DIFF
--- a/src/services/extensionHelperService.ts
+++ b/src/services/extensionHelperService.ts
@@ -1,5 +1,18 @@
 import { checkKeysign } from '../utils/handshake';
 
+interface KSLoginResult {
+  success: boolean;
+  data: {
+    accountNumber: string;
+    request_id: number;
+    result: {
+      accountNumber: '739d35d4acf47819c2607321d4c65db41359d48387ce8b366e07c20adaacd73d';
+      verified: true;
+    };
+    type: string;
+  };
+}
+
 export default class ExtensionHelperService {
   static checkIfExtensionExists(): Promise<boolean> {
     return new Promise((resolve, reject) => {
@@ -10,7 +23,7 @@ export default class ExtensionHelperService {
     });
   }
 
-  static validateKSLogin(accountNumber: string): Promise<boolean> {
+  static validateKSLogin(accountNumber?: string): Promise<KSLoginResult> {
     return new Promise((resolve) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore


### PR DESCRIPTION
removes the input field for account number on keysign login in favor of
pulling the account number from the keysign extension's validation
response.

Also adds a type for the keysign validation response, although this may
need to be changed since it looks like the keysign response has some
redundant fields